### PR TITLE
ARM: dts: imx6q-omni1000: Adds USB OTG support

### DIFF
--- a/arch/arm/boot/dts/imx6q-omni1000.dts
+++ b/arch/arm/boot/dts/imx6q-omni1000.dts
@@ -136,6 +136,10 @@
 	status = "okay";
 };
 
+&usbotg {
+        status = "okay";
+};
+
 &usdhc1 {
 	status = "okay";
 };


### PR DESCRIPTION
Adds USB OTG support for the imx6q-omni1000 board.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>