### PR TITLE
ARM: dts: imx6q-omni1000: Add support for goodix touchscreen controller

### DIFF
--- a/arch/arm/boot/dts/imx6q-omni1000.dts
+++ b/arch/arm/boot/dts/imx6q-omni1000.dts
@@ -118,6 +118,18 @@
 		interrupt-parent = <&gpio3>;
 		interrupts = <10 IRQ_TYPE_LEVEL_HIGH>;
 	};
+
+	touchscreen@5d {
+		compatible = "goodix,gt928";
+		reg = <0x5d>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_touchscreen>;
+		interrupt-parent = <&gpio3>;
+		interrupts = <12 IRQ_TYPE_EDGE_FALLING>;
+		irq-gpios = <&gpio3 12 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio2 22 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
 };
 
 &i2c3 {
@@ -250,5 +262,13 @@
 		fsl,pins = <
 		        MX6QDL_PAD_EIM_DA10__GPIO3_IO10 0x1b0b0
 	        >;
+	};
+
+	pinctrl_touchscreen: touchscreengrp {
+		fsl,pins = <
+			MX6QDL_PAD_EIM_A16__GPIO2_IO22 0x1b0b0
+			MX6QDL_PAD_EIM_DA11__GPIO3_IO11 0x1b0b0
+			MX6QDL_PAD_EIM_DA12__GPIO3_IO12 0x130b0
+		>;
 	};
 };


### PR DESCRIPTION
Add support for omni1000 for the goodix touchscreen controller, for
displays of 10 inch.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>