### PR TITLE
ARM: dts: imx6q-omni1000: Limit the operation at 100Mbps

### DIFF
--- a/arch/arm/boot/dts/imx6q-omni1000.dts
+++ b/arch/arm/boot/dts/imx6q-omni1000.dts
@@ -86,6 +86,13 @@
 				 <&clks IMX6QDL_CLK_PLL2_PFD2_396M>;
 };
 
+/* Limits the operation at 100Mbps.
+ * Unstable behavior is seen at 1Gbps on the imx6q-omni1000 board.
+ */
+&ethphy {
+	max-speed = <100>;
+};
+
 &gpio1 {
         gpio-line-names = "", "", "", "", "", "", "", "",
                         "", "", "", "", "", "", "", "IRQ_BUTTON",


### PR DESCRIPTION
Unstable behavior is seen at 1Gbps on the imx6q-omni1000 board.

Limit the speed at 100Mbps for now.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>