### PR TITLE
imx6q-omni1000: Remove the reset-gpio on touchscreen node

### DIFF
--- a/arch/arm/boot/dts/imx6q-omni1000.dts
+++ b/arch/arm/boot/dts/imx6q-omni1000.dts
@@ -151,7 +151,6 @@
 		interrupt-parent = <&gpio3>;
 		interrupts = <12 IRQ_TYPE_EDGE_FALLING>;
 		irq-gpios = <&gpio3 12 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&gpio2 22 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Stop resetting the controller at probe, it allows for the probe
to be done using existinginternal config and avoids reading the firmware from disk.

Signed-off-by: rafluan <luan.rafael@ossystems.com.br>