### PR TITLE
ARM: dts: am335x-mfc: Define GPIO's for modem support

### DIFF
--- a/arch/arm/boot/dts/am335x-mfc.dts
+++ b/arch/arm/boot/dts/am335x-mfc.dts
@@ -390,6 +390,13 @@
 		>;
 	};
 
+	gsm_modem: gsm_modem {
+		pinctrl-single,pins = <
+			AM33XX_PADCONF(AM335X_PIN_EMU0, PIN_OUTPUT_PULLUP, MUX_MODE7)
+			AM33XX_PADCONF(AM335X_PIN_EMU1, PIN_OUTPUT_PULLUP, MUX_MODE7)
+		>;
+	};
+
 	user_leds: user_leds {
 		pinctrl-single,pins = <
 			AM33XX_PADCONF(AM335X_PIN_GPMC_AD9, PIN_OUTPUT, MUX_MODE7)


### PR DESCRIPTION
Define GPIO's for Ublox modem initialization.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>