### PR TITLE
ARM: dts: imx6ull-geodata: Adapt for using Wifi via USB

### DIFF
--- a/arch/arm/boot/dts/imx6ull-geodata.dts
+++ b/arch/arm/boot/dts/imx6ull-geodata.dts
@@ -14,7 +14,6 @@
 	
 	aliases {
 		mmc0 = &usdhc2;
-		mmc1 = &usdhc1;
 	};
 
 	memory@80000000 {
@@ -22,13 +21,14 @@
 		reg = <0x80000000 0x20000000>;
 	};
 
-	reg_emmc: regulator-emmc {
+	reg_wifi: regulator-wifi {
 		compatible = "regulator-fixed";
 		regulator-name = "emmc_vcc";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		gpio = <&gpio2 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+		regulator-always-on;
 	};
 
 	leds {
@@ -151,17 +151,6 @@
 	fsl,tx-d-cal = <106>;
 };
 
-&usdhc1 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_usdhc1>;
-	no-1-8-v;
-	non-removable;
-	bus-width = <4>;
-	vmmc-supply = <&reg_emmc>;
-	keep-power-in-suspend;
-	status = "okay";
-};
-
 &usdhc2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_usdhc2>;
@@ -215,17 +204,6 @@
 		fsl,pins = <
 			MX6UL_PAD_UART1_TX_DATA__UART1_DCE_TX	0x1b0b1
 			MX6UL_PAD_UART1_RX_DATA__UART1_DCE_RX	0x1b0b1
-		>;
-	};
-
-	pinctrl_usdhc1: usdhc1grp {
-		fsl,pins = <
-			MX6UL_PAD_SD1_CMD__USDHC1_CMD		0x17059
-			MX6UL_PAD_SD1_CLK__USDHC1_CLK		0x10071
-			MX6UL_PAD_SD1_DATA0__USDHC1_DATA0	0x17059
-			MX6UL_PAD_SD1_DATA1__USDHC1_DATA1	0x17059
-			MX6UL_PAD_SD1_DATA2__USDHC1_DATA2	0x17059
-			MX6UL_PAD_SD1_DATA3__USDHC1_DATA3	0x17059
 		>;
 	};
 


### PR DESCRIPTION
The second imx6ull-geodata board revision uses the RS9116 chip
via USB interface instead of SDIO.

Do the necessary changes to accomodate that.

Signed-off-by: Fabio Estevam <festevam@gmail.com>
Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>